### PR TITLE
Remove rdfextras dependency, fix docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,9 +22,8 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
-MOCK_MODULES = ['pycurl']
+MOCK_MODULES = ['pycurl','rdflib']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from unittest.mock import MagicMock
+from mock import MagicMock
 import sys
 import os
 import shlex

--- a/nidm/query.py
+++ b/nidm/query.py
@@ -14,8 +14,6 @@ import numpy
 import rdflib
 import shutil
 import tempfile
-import rdfextras
-rdfextras.registerplugins()
 import sys
 if sys.version_info[0] < 3:
     from StringIO import StringIO

--- a/nidm/script/post_install.py
+++ b/nidm/script/post_install.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 import os
 
-os.system("pip install rdflib --user")
+os.system("pip install rdflib")
 print "Run server with command 'nidm'"
 

--- a/nidm/script/post_install.py
+++ b/nidm/script/post_install.py
@@ -1,3 +1,6 @@
 #!/usr/bin/python
+import os
 
+os.system("pip install rdflib --user")
 print "Run server with command 'nidm'"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
 flask
 gitpython
-rdflib
 flask-restful

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
 flask
 gitpython
+rdflib
 flask-restful

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 numpy
 flask
 gitpython
-rdfextras
 flask-restful
-rdflib>=4.2.0

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ import codecs
 import sys
 import os
 
+reqs = [line.strip() for line in open('requirements.txt').readlines()]
+requirements = list(filter(None, reqs))
+
 # Post install script, if needed
 def _post_install(dir):
     from subprocess import call
@@ -49,7 +52,7 @@ setup(
     long_description=long_description,
     keywords='neuroscience, NIDM',
 
-    install_requires = ['numpy','Flask','gitpython'],
+    install_requires = requirements,
 
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
This PR should do the following:
- remove dependency on rdfextras (I don't think it was being used)
- fix documentation rendering - to do this I have rdflib installed post setup.py, and add the other modules that require c compilation as "mock" in the readthedocs conf.py. With these two changes, the requirements.txt should be installed and the docs should be built correctly (it works on my branch).
